### PR TITLE
Make Contact properties protected

### DIFF
--- a/Entity/Contact.php
+++ b/Entity/Contact.php
@@ -20,28 +20,28 @@ class Contact
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    private $id;
+    protected $id;
 
     /**
      * @var email
      *
      * @ORM\Column(name="email", type="string", length=255, nullable=false)
      */
-    private $email;
+    protected $email;
 
     /**
      * @var message
      *
      * @ORM\Column(name="message", type="text", nullable=false)
      */
-    private $message;
+    protected $message;
 
     /**
      * @var datetime
      *
      * @ORM\Column(name="creation", type="datetime", nullable=false)
      */
-    private $creation;
+    protected $creation;
 
     public function __construct()
     {


### PR DESCRIPTION
If the parent class properties are private they are not visible for the child class, so doctrine can't add them to the class mapping.