### PR TITLE
bug : fix the deprecation warning in routing file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,10 @@ matrix:
       env: SYMFONY_VERSION=4.4.*
     - php: 7.3
       env: SYMFONY_VERSION=5.0.*
-#    - php: 7.4
-#      env: SYMFONY_VERSION=3.4.*
-#    - php: 7.4
-#      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
   allow_failures:
     - php: hhvm
 

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -5,10 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="tlh_contact_form" path="/contact" methods="GET POST">
-        <default key="_controller">TLHContactBundle:Contact:form</default>
+        <default key="_controller">TLH\ContactBundle\Controller\ContactController::formAction</default>
     </route>
     <route id="tlh_contact_form_create" path="/contact/create" methods="POST">
-        <default key="_controller">TLHContactBundle:Contact:formCreate</default>
+        <default key="_controller">TLH\ContactBundle\Controller\ContactController::formCreateAction</default>
     </route>
 
 </routes>


### PR DESCRIPTION
The routing file had to be modified.

```
Referencing controllers with TLHContactBundle:Contact:form is deprecated since Symfony 4.1
```